### PR TITLE
Replace hourly countdown with minute or hour depending on remaining time

### DIFF
--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -95,7 +95,7 @@
                             <p id="day3"></p>
                         </div>
                     </div>
-                    <div class="col center countdownDays">Days</div>
+                    <div class="col center countdownDays" id="countdownUnit">Days</div>
                 </div>
             </div>
         </div>

--- a/hackathon_site/event/static/event/js/landing.js
+++ b/hackathon_site/event/static/event/js/landing.js
@@ -72,6 +72,26 @@ function setCounter(countDownDate) {
     const now = new Date();
     const distance = countDownDate - now;
     const days = Math.ceil(distance / (1000 * 60 * 60 * 24));
+    const hours = Math.ceil(distance / (1000 * 60 * 60));
+
+    if (hours < 2) {
+        const minutes = Math.ceil(distance / (1000 * 60));
+        // Change to show minutes on the website
+        $("#day1").parent().remove();
+        $("#day2").html(Math.floor(minutes / 10) % 10);
+        $("#day3").html(minutes % 10);
+        $("#countdownUnit").html("Minutes");
+        return;
+    }
+
+    if (days < 3) {
+        // Change to show hours on the website
+        $("#day1").parent().remove();
+        $("#day2").html(Math.floor(hours / 10) % 10);
+        $("#day3").html(hours % 10);
+        $("#countdownUnit").html("Hours");
+        return;
+    }
 
     // Check if we need a third digit or not
     if (days > 99) {

--- a/hackathon_site/event/static/event/js/landing.js
+++ b/hackathon_site/event/static/event/js/landing.js
@@ -74,22 +74,22 @@ function setCounter(countDownDate) {
     const days = Math.floor(distance / (1000 * 60 * 60 * 24));
     const hours = Math.floor(distance / (1000 * 60 * 60));
 
-    if (hours < 2) {
+    if (hours < 1) {
         const minutes = Math.floor(distance / (1000 * 60));
         // Change to show minutes on the website
         $("#day1").parent().remove();
         $("#day2").html(Math.floor(minutes / 10));
         $("#day3").html(minutes % 10);
-        $("#countdownUnit").html("Minutes");
+        $("#countdownUnit").html(minutes == 1 ? "Minute" : "Minutes");
         return;
     }
 
-    if (days < 3) {
+    if (days < 2) {
         // Change to show hours on the website
         $("#day1").parent().remove();
         $("#day2").html(Math.floor(hours / 10));
         $("#day3").html(hours % 10);
-        $("#countdownUnit").html("Hours");
+        $("#countdownUnit").html(hours == 1 ? "Hour" : "Hours");
         return;
     }
 

--- a/hackathon_site/event/static/event/js/landing.js
+++ b/hackathon_site/event/static/event/js/landing.js
@@ -71,14 +71,14 @@ $(document).ready(function () {
 function setCounter(countDownDate) {
     const now = new Date();
     const distance = countDownDate - now;
-    const days = Math.ceil(distance / (1000 * 60 * 60 * 24));
-    const hours = Math.ceil(distance / (1000 * 60 * 60));
+    const days = Math.floor(distance / (1000 * 60 * 60 * 24));
+    const hours = Math.floor(distance / (1000 * 60 * 60));
 
     if (hours < 2) {
-        const minutes = Math.ceil(distance / (1000 * 60));
+        const minutes = Math.floor(distance / (1000 * 60));
         // Change to show minutes on the website
         $("#day1").parent().remove();
-        $("#day2").html(Math.floor(minutes / 10) % 10);
+        $("#day2").html(Math.floor(minutes / 10));
         $("#day3").html(minutes % 10);
         $("#countdownUnit").html("Minutes");
         return;
@@ -87,7 +87,7 @@ function setCounter(countDownDate) {
     if (days < 3) {
         // Change to show hours on the website
         $("#day1").parent().remove();
-        $("#day2").html(Math.floor(hours / 10) % 10);
+        $("#day2").html(Math.floor(hours / 10));
         $("#day3").html(hours % 10);
         $("#countdownUnit").html("Hours");
         return;

--- a/hackathon_site/event/static/event/js/landing.js
+++ b/hackathon_site/event/static/event/js/landing.js
@@ -80,7 +80,7 @@ function setCounter(countDownDate) {
         $("#day1").parent().remove();
         $("#day2").html(Math.floor(minutes / 10));
         $("#day3").html(minutes % 10);
-        $("#countdownUnit").html(minutes == 1 ? "Minute" : "Minutes");
+        $("#countdownUnit").html(minutes === 1 ? "Minute" : "Minutes");
         return;
     }
 
@@ -89,7 +89,7 @@ function setCounter(countDownDate) {
         $("#day1").parent().remove();
         $("#day2").html(Math.floor(hours / 10));
         $("#day3").html(hours % 10);
-        $("#countdownUnit").html(hours == 1 ? "Hour" : "Hours");
+        $("#countdownUnit").html(hours === 1 ? "Hour" : "Hours");
         return;
     }
 


### PR DESCRIPTION
## Overview

https://ieeeuoft2021-2022.slack.com/archives/C01TC1VSEKS/p1644122921328709

What I see rn at 12:25AM when the registration is closing at 11:59PM tonight:
<img width="371" alt="Screen Shot 2022-02-06 at 12 33 51 AM" src="https://user-images.githubusercontent.com/42653157/152668943-b077bb29-f14f-4413-859c-f4a32944f64e.png">

Singular vs plural unit:
![Screen Shot 2022-02-06 at 12 40 08 AM](https://user-images.githubusercontent.com/42653157/152669218-45513e9a-eb0d-4446-9203-b08460beab9e.png)
![Screen Shot 2022-02-06 at 12 43 52 AM](https://user-images.githubusercontent.com/42653157/152669219-3d9ddaa6-acad-47fa-b75b-730eab99e571.png)


## Unit Tests Created

- N/A


## Steps to QA

- Manipulate `REGISTRATION_CLOSE_DATE` and make sure the countdown number makes sense to you

